### PR TITLE
Fix regexp error and mix warning

### DIFF
--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -20,7 +20,7 @@ defmodule XmlToMap do
 
   def naive_map(xml) do
     #can't handle xmlns
-    xml = String.replace(xml, ~r/\sxmlns=\"\S+\"/, "")
+    xml = String.replace(xml, ~r/(\sxmlns="\S+")|(xmlns:ns2="\S+")/, "")
     {:ok, tuples, _} = :erlsom.simple_form(xml)
     NaiveMap.parse(tuples)
   end

--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -1,5 +1,5 @@
 defmodule XmlToMap do
-  
+
   @moduledoc """
   Simple convenience module for getting a map out of an XML string.
   """
@@ -7,20 +7,20 @@ defmodule XmlToMap do
   alias XmlToMap.NaiveMap
 
   @doc """
-  naive_map(xml) utility is inspired by Rails Hash.from_xml() 
-  but is "naive" in that it is convenient (requires no setup) 
+  naive_map(xml) utility is inspired by Rails Hash.from_xml()
+  but is "naive" in that it is convenient (requires no setup)
   but carries the same drawbacks. Use with caution.
 
-  XML and Maps are non-isomorphic.  
-  Attributes on some nodes don't carry over if the node has just 
+  XML and Maps are non-isomorphic.
+  Attributes on some nodes don't carry over if the node has just
   one text value (like a leaf). Naive map has no validation over
    what should be a collection.  If and only if nodes are repeated
-    at the same level will they beome a list.  
+    at the same level will they beome a list.
   """
 
   def naive_map(xml) do
     #can't handle xmlns
-    xml = String.replace(xml, ~r/\sxmlns=\".*\"/, "")
+    xml = String.replace(xml, ~r/\sxmlns=\"\S+\"/, "")
     {:ok, tuples, _} = :erlsom.simple_form(xml)
     NaiveMap.parse(tuples)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule XmlToMap.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "A module for converting an XML string to a map",
-     package: package,
+     package: package(),
      deps: deps()]
   end
 

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -3,11 +3,11 @@ defmodule XmlToMapTest do
   doctest XmlToMap
 
   test "make a map" do
-    assert XmlToMap.naive_map(sample_xml) == expectation
+    assert XmlToMap.naive_map(sample_xml()) == expectation()
   end
 
   test "combines sibling nodes with the same name into a list" do
-    assert XmlToMap.naive_map(amazon_xml) == amazon_expected
+    assert XmlToMap.naive_map(amazon_xml()) == amazon_expected()
   end
 
   def expectation do


### PR DESCRIPTION
Fixes erlsom parse error:

```elixir
** (throw) {:error, 'Malformed: Tags don\'t match'}
    /Users/retgoat/workspace/fox/protos/elixir-amazon-mws-client/deps/erlsom/src/erlsom_sax_utf8.erl:912: :erlsom_sax_utf8.parseContentLT/2
    /Users/retgoat/workspace/fox/protos/elixir-amazon-mws-client/deps/erlsom/src/erlsom_sax_utf8.erl:196: :erlsom_sax_utf8.parse/2
```

Original regexp works like this: http://rubular.com/r/gjCBl1ekDE