### PR TITLE
Resolve compiler warning in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule XmlToMap.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "A module for converting an XML string to a map",
-     package: package,
+     package: package(),
      deps: deps()]
   end
 


### PR DESCRIPTION
```
| warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
|   /app/deps/elixir_xml_to_map/mix.exs:11
```