### PR TITLE
Leaf node attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore asdf artifacts
+/.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 20.2
+elixir 1.6.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-erlang 20.2
-elixir 1.6.1

--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -1,5 +1,4 @@
 defmodule XmlToMap do
-  
   @moduledoc """
   Simple convenience module for getting a map out of an XML string.
   """
@@ -7,15 +6,15 @@ defmodule XmlToMap do
   alias XmlToMap.NaiveMap
 
   @doc """
-  naive_map(xml) utility is inspired by Rails Hash.from_xml() 
-  but is "naive" in that it is convenient (requires no setup) 
+  naive_map(xml) utility is inspired by Rails Hash.from_xml()
+  but is "naive" in that it is convenient (requires no setup)
   but carries the same drawbacks. Use with caution.
 
-  XML and Maps are non-isomorphic.  
-  Attributes on some nodes don't carry over if the node has just 
+  XML and Maps are non-isomorphic.
+  Attributes on some nodes don't carry over if the node has just
   one text value (like a leaf). Naive map has no validation over
    what should be a collection.  If and only if nodes are repeated
-    at the same level will they beome a list.  
+    at the same level will they beome a list.
   """
 
   def naive_map(xml) do
@@ -24,5 +23,4 @@ defmodule XmlToMap do
     {:ok, tuples, _} = :erlsom.simple_form(xml)
     NaiveMap.parse(tuples)
   end
-
 end

--- a/lib/xml_to_map/naive_map.ex
+++ b/lib/xml_to_map/naive_map.ex
@@ -4,7 +4,7 @@ defmodule XmlToMap.NaiveMap do
   Module to recursively traverse the output of erlsom.simple_form
   and produce a map.
 
-  erlsom uses character lists so this library converts them to 
+  erlsom uses character lists so this library converts them to
   Elixir binary string.
   """
 
@@ -18,27 +18,29 @@ defmodule XmlToMap.NaiveMap do
   def parse({name, attr, content}) do
     parsed_content = parse(content)
     case is_map(parsed_content) do
-      true -> 
+      true ->
         %{to_string(name) => parsed_content |> Map.merge(attr_map(attr))}
       false ->
-        %{to_string(name) => parsed_content}
+        %{to_string(name) => (if attr_map(attr) == %{} do
+          parsed_content
+        else
+          attr |> attr_map() |> Map.put_new(to_string(name), parsed_content)
+        end)}
     end
   end
 
   def parse(list) when is_list(list) do
-    parsed_list = Enum.map list, &({to_string(elem(&1,0)), parse(&1)}) 
-    Enum.reduce parsed_list, %{}, fn {k,v}, acc -> 
+    parsed_list = Enum.map list, &({to_string(elem(&1,0)), parse(&1)})
+    Enum.reduce parsed_list, %{}, fn {k,v}, acc ->
       case Map.get(acc, k) do
         nil -> Map.put_new(acc, k, v[k])
         [h|t] -> Map.put(acc, k, [h|t] ++ [v[k]])
         prev -> Map.put(acc, k, [prev] ++ [v[k]])
       end
-    end 
+    end
   end
 
   defp attr_map(list) do
     list |> Enum.map(fn {k,v} -> {to_string(k), to_string(v)} end) |> Map.new
   end
-
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule XmlToMap.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "A module for converting an XML string to a map",
-     package: package,
+     package: package(),
      deps: deps()]
   end
 

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -3,18 +3,19 @@ defmodule XmlToMapTest do
   doctest XmlToMap
 
   test "make a map" do
-    assert XmlToMap.naive_map(sample_xml) == expectation
+    assert XmlToMap.naive_map(sample_xml()) == expectation()
   end
 
   test "combines sibling nodes with the same name into a list" do
-    assert XmlToMap.naive_map(amazon_xml) == amazon_expected
+    assert XmlToMap.naive_map(amazon_xml()) == amazon_expected()
   end
 
   def expectation do
     %{"Orders" => %{"foo" => "bar",
     "order" => [%{"billing_address" => "My address", "id" => "123",
        "items" => %{"item" => %{"description" => "Hat", "itemfoo" => "itembar",
-           "price" => "5.99", "quantity" => "1", "sku" => "ABC"},
+           "price" => "5.99", "quantity" => "1",
+           "sku" => %{"sku" => "ABC", "skufoo" => "skubar"}},
          "itemsfoo" => "itemsbar"}},
      %{"billing_address" => "Uncle's House", "id" => "124",
        "items" => %{"item" => %{"description" => "Hat", "price" => "5.99",


### PR DESCRIPTION
NOTE: I fully expect this PR to get rejected...

In the XML I'm working with I have leaf nodes with meaningful attributes. I struggled a bit with how I'd want that represented and in the end chose to repeat the node key and merge it in with the attributes if there were attributes.

So in the tests `<sku skufoo="skubar">ABC</sku>` renders out as `%{"sku" => %{"sku" => "ABC", "skufoo" => "skubar"}}` but `<description>Hat</description>` renders as `%{"description" => "Hat"}`

Everything else I came up with seemed needlessly noisy.

Anywho - I'm gonna assume this is an edge case and will just point my project to my fork... but wanted to PR back in case a conversation showed me a better solution than what I ended up using.