### PR TITLE
switches to automatic application inference

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule XmlToMap.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
While the `:erlsom` dependency works fine in development, when I create a release using Distillery, the dependency is not found:

```
==> One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

    :erlsom

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.
```

Switching to automatic application inference as [explained here](https://elixirforum.com/t/dependencys-dependencies-not-found-in-production/10563/2) and [here](https://github.com/jsonkenl/xlsxir/pull/72) fixes this issue.