### PR TITLE
Introduce xml's attributes in the parsed structure

### DIFF
--- a/lib/xml_to_map/naive_map.ex
+++ b/lib/xml_to_map/naive_map.ex
@@ -4,8 +4,10 @@ defmodule XmlToMap.NaiveMap do
   Module to recursively traverse the output of erlsom.simple_form
   and produce a map.
 
-  erlsom uses character lists so this library converts them to 
+  erlsom uses character lists so this library converts them to
   Elixir binary string.
+
+  Attributes, if present, are defined as tag@attribute_name => attribute_value
   """
 
   def parse([value]) do
@@ -16,29 +18,32 @@ defmodule XmlToMap.NaiveMap do
   end
 
   def parse({name, attr, content}) do
+    attributes = Enum.reduce(attr, %{}, fn({attribute_name, attribute_value}, acc) ->
+      Map.put(acc, "#{name}@#{attribute_name}", to_string(attribute_value))
+    end)
     parsed_content = parse(content)
     case is_map(parsed_content) do
-      true -> 
-        %{to_string(name) => parsed_content |> Map.merge(attr_map(attr))}
+      true ->
+        %{to_string(name) => parsed_content |> Map.merge(attr_map(attr)) |> Map.merge(attributes)}
       false ->
-        %{to_string(name) => parsed_content}
+        %{to_string(name) => parsed_content} |> Map.merge(attributes)
     end
   end
 
   def parse(list) when is_list(list) do
-    parsed_list = Enum.map list, &({to_string(elem(&1,0)), parse(&1)}) 
-    Enum.reduce parsed_list, %{}, fn {k,v}, acc -> 
+    parsed_list = Enum.map list, &({to_string(elem(&1, 0)), parse(&1)})
+    Enum.reduce parsed_list, %{}, fn {k,v}, acc ->
       case Map.get(acc, k) do
-        nil -> Map.put_new(acc, k, v[k])
+        nil ->
+          (for {key, value} <- v, into: %{}, do: {key, value})
+          |> Map.merge(acc)
         [h|t] -> Map.put(acc, k, [h|t] ++ [v[k]])
         prev -> Map.put(acc, k, [prev] ++ [v[k]])
       end
-    end 
+    end
   end
 
   defp attr_map(list) do
     list |> Enum.map(fn {k,v} -> {to_string(k), to_string(v)} end) |> Map.new
   end
-
-
 end

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -11,14 +11,31 @@ defmodule XmlToMapTest do
   end
 
   def expectation do
-    %{"Orders" => %{"foo" => "bar",
-    "order" => [%{"billing_address" => "My address", "id" => "123",
-       "items" => %{"item" => %{"description" => "Hat", "itemfoo" => "itembar",
-           "price" => "5.99", "quantity" => "1", "sku" => "ABC"},
-         "itemsfoo" => "itemsbar"}},
-     %{"billing_address" => "Uncle's House", "id" => "124",
-       "items" => %{"item" => %{"description" => "Hat", "price" => "5.99",
-           "quantity" => "2", "sku" => "ABC"}}}]}}
+    %{"Orders" =>
+      %{"foo" => "bar",
+        "order" => [%{"billing_address" => "My address", "id" => "123",
+                      "items" => %{"item" => [%{"description" => "Hat",
+                                               "item@itemfoo" => "itembar",
+                                               "itemfoo" => "itembar",
+                                               "price" => "5.99",
+                                               "quantity" => "1",
+                                               "sku" => "ABC",
+                                               "sku@skufoo" => "skubar"},
+                                              %{"description" => "Bat",
+                                                "item@itemfoo" => "itembaz",
+                                                "itemfoo" => "itembaz",
+                                                "price" => "9.99",
+                                                "quantity" => "2",
+                                                "sku" => "ABC"}],
+                                   "itemsfoo" => "itemsbar",
+                                   "items@itemsfoo" => "itemsbar"}},
+                    %{"billing_address" => "Uncle's House", "id" => "124",
+                      "items" => %{"item" => %{"description" => "Hat",
+                                               "price" => "5.99",
+                                               "quantity" => "2",
+                                               "sku" => "ABC"}}
+                    }],
+        "Orders@foo" => "bar"}}
   end
 
 
@@ -35,6 +52,14 @@ defmodule XmlToMapTest do
             <price>5.99</price>
             <quantity>
               1
+            </quantity>
+          </item>
+          <item itemfoo="itembaz">
+            <sku>ABC</sku>
+            <description>Bat</description>
+            <price>9.99</price>
+            <quantity>
+              2
             </quantity>
           </item>
         </items>


### PR DESCRIPTION
There are couple ideas behind these changes:
* Introduce attributes as part of the structure. It works by recording the attributes at the current level;
* Use the `tag@attribute_name => attribute_value` notation;
* Do not investigate if there are blanks in another leafs, where are supposed to be identical attributes.

I'm open for discussion if the notation is explicit and inclusive enough.