### PR TITLE
Add support for xmlns xml file

### DIFF
--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -15,9 +15,33 @@ defmodule XmlToMap do
   attributes we'll prepend a "-" in front of them and merge them into the map
   and take the node value and nest that inside "#content" key.
   """
-  def naive_map(xml, namespace_match_fn \\ nil) do
-    tree = get_generic_data_structure(xml, namespace_match_fn)
+  def naive_map(xml, opts \\ %{}) do
+    tree = get_generic_data_structure(xml, opts)
     NaiveMap.parse(tree)
+  end
+
+  # Default function to handle namespace in xml
+  # This fuction invokes an anonymous function that has this parameters: Name, Namespace, Prefix.
+  # Usually, the namespace appears at the top of xml file, e.g `xmlns:g="http://base.google.com/ns/1.0"`,
+  # where `g` is the Prefix and `"http://base.google.com/ns/1.0"` the Namespace,
+  # the Name is the key tag in xml.
+  # It should return a term. It is called for each tag and attribute name.
+  # The result will be used in the output.
+  # When a namespace and prefix is found, it'll return a term like "#{prefix}:#{name}",
+  # otherwise it will return only the name.
+  # The default behavior in :erlsom.simple_form/2 is Name if Namespace == undefined, and a string {Namespace}Name otherwise.
+  def default_namespace_match_fn do
+    fn(name, namespace, prefix) ->
+      cond do
+        namespace != [] && prefix != [] -> "#{prefix}:#{name}"
+        true -> name
+      end
+    end
+  end
+
+  defp get_generic_data_structure(xml, %{namespace_match_fn: namespace_match_fn} = opts) do
+    {:ok, element, _tail} = :erlsom.simple_form(xml, [{:nameFun, namespace_match_fn}])
+    element
   end
 
   # erlsom simple_form returns a kind of tree:
@@ -26,13 +50,8 @@ defmodule XmlToMap do
   # Tag is a string
   # Attributes = [{AttributeName, Value}],
   # Content is a list of Elements and/or strings.
-  defp get_generic_data_structure(xml, nil) do
+  defp get_generic_data_structure(xml, _opts) do
     {:ok, element, _tail} = :erlsom.simple_form(xml)
-    element
-  end
-
-  defp get_generic_data_structure(xml, namespace_match_fn) do
-    {:ok, element, _tail} = :erlsom.simple_form(xml, [{:nameFun, namespace_match_fn}])
     element
   end
 end

--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -15,12 +15,12 @@ defmodule XmlToMap do
   attributes we'll prepend a "-" in front of them and merge them into the map
   and take the node value and nest that inside "#content" key.
   """
-  def naive_map(xml) do
+  def naive_map(xml, namespace_match_fn \\ nil) do
     # can't handle xmlns, if left in will prepend every output map
     # key with the xmlns value in curly braces
-    xml = String.replace(xml, ~r/(\sxmlns="\S+")|(xmlns:ns2="\S+")/, "")
+    # xml = String.replace(xml, ~r/(\sxmlns="\S+")|(xmlns:ns2="\S+")/, "")
 
-    tree = get_generic_data_structure(xml)
+    tree = get_generic_data_structure(xml, namespace_match_fn)
     NaiveMap.parse(tree)
   end
 
@@ -30,8 +30,13 @@ defmodule XmlToMap do
   # Tag is a string
   # Attributes = [{AttributeName, Value}],
   # Content is a list of Elements and/or strings.
-  defp get_generic_data_structure(xml) do
+  defp get_generic_data_structure(xml, nil) do
     {:ok, element, _tail} = :erlsom.simple_form(xml)
+    element
+  end
+
+  defp get_generic_data_structure(xml, namespace_match_fn) do
+    {:ok, element, _tail} = :erlsom.simple_form(xml, [{:nameFun, namespace_match_fn}])
     element
   end
 end

--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -15,8 +15,11 @@ defmodule XmlToMap do
   attributes we'll prepend a "-" in front of them and merge them into the map
   and take the node value and nest that inside "#content" key.
   """
-  def naive_map(xml, opts \\ %{}) do
-    tree = get_generic_data_structure(xml, opts)
+  @defaults %{namespace_match_fn: &__MODULE__.default_namespace_match_fn/0}
+
+  def naive_map(xml, opts \\ []) do
+    params = Enum.into(opts, @defaults)
+    tree = get_generic_data_structure(xml, params)
     NaiveMap.parse(tree)
   end
 
@@ -39,8 +42,8 @@ defmodule XmlToMap do
     end
   end
 
-  defp get_generic_data_structure(xml, %{namespace_match_fn: namespace_match_fn} = opts) do
-    {:ok, element, _tail} = :erlsom.simple_form(xml, [{:nameFun, namespace_match_fn}])
+  defp get_generic_data_structure(xml, %{namespace_match_fn: namespace_match_fn}) do
+    {:ok, element, _tail} = :erlsom.simple_form(xml, [{:nameFun, namespace_match_fn.()}])
     element
   end
 

--- a/lib/elixir_xml_to_map.ex
+++ b/lib/elixir_xml_to_map.ex
@@ -16,10 +16,6 @@ defmodule XmlToMap do
   and take the node value and nest that inside "#content" key.
   """
   def naive_map(xml, namespace_match_fn \\ nil) do
-    # can't handle xmlns, if left in will prepend every output map
-    # key with the xmlns value in curly braces
-    # xml = String.replace(xml, ~r/(\sxmlns="\S+")|(xmlns:ns2="\S+")/, "")
-
     tree = get_generic_data_structure(xml, namespace_match_fn)
     NaiveMap.parse(tree)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule XmlToMap.Mixfile do
   def project do
     [
       app: :elixir_xml_to_map,
-      version: "2.0.0",
+      version: "3.0.0",
       elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -33,6 +33,10 @@ defmodule XmlToMapTest do
            }
   end
 
+  test "support for custom namespace_match function" do
+    assert XmlToMap.naive_map(facebook_xmlns_xml(), [namespace_match_fn: &set_prefix_namespace_fn/0]) == facebook_custom_function_expected()
+  end
+
   test "support for xmlns xml file" do
     assert XmlToMap.naive_map(facebook_xmlns_xml(), [namespace_match_fn: &XmlToMap.default_namespace_match_fn/0]) == facebook_xmlns_xml_expected()
   end
@@ -259,6 +263,48 @@ defmodule XmlToMapTest do
           ]
         },
         "ResponseMetadata" => %{"RequestId" => "7509cdb2-0b69-4ca0-89dc-c77f8a747834"}
+      }
+    }
+  end
+
+  def set_prefix_namespace_fn do
+    fn(name, namespace, prefix) ->
+      cond do
+        namespace != [] && prefix != [] -> "#{prefix}_namespace:#{name}"
+        true -> name
+      end
+    end
+  end
+
+  def facebook_custom_function_expected do
+    %{
+      "rss" => %{
+        "#content" => %{
+          "channel" => %{
+            "title" => "Test Store",
+            "link" => "http://www.example.com",
+            "description" => "An example item from the feed",
+            "item" => %{
+              "g_namespace:id" => "DB_1",
+              "g_namespace:title" => "Dog Bowl In Blue",
+              "g_namespace:description" => "Solid plastic Dog Bowl in marine blue color",
+              "g_namespace:link" => "http://www.example.com/bowls/db-1.html",
+              "g_namespace:image_link" => "http://images.example.com/DB_1.png",
+              "g_namespace:brand" => "Example",
+              "g_namespace:condition" => "new",
+              "g_namespace:availability" => "in stock",
+              "g_namespace:price" => "9.99 GBP",
+              "g_namespace:shipping" => %{
+                "g_namespace:country" => "UK",
+                "g_namespace:service" => "Standard",
+                "g_namespace:price" => "4.95 GBP",
+              },
+              "g_namespace:google_product_category" => "Animals > Pet Supplies",
+              "g_namespace:custom_label_0" => "Made in Waterford, IE",
+            }
+          }
+        },
+        "-version" => "2.0"
       }
     }
   end

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -38,7 +38,7 @@ defmodule XmlToMapTest do
   end
 
   test "support for xmlns xml file" do
-    assert XmlToMap.naive_map(facebook_xmlns_xml(), [namespace_match_fn: &XmlToMap.default_namespace_match_fn/0]) == facebook_xmlns_xml_expected()
+    assert XmlToMap.naive_map(facebook_xmlns_xml()) == facebook_xmlns_xml_expected()
   end
 
   def expectation do

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -7,7 +7,8 @@ defmodule XmlToMapTest do
   end
 
   test "combines sibling nodes with the same name into a list" do
-    assert XmlToMap.naive_map(amazon_xml(), fn(name, namespace, prefix) -> name end) == amazon_expected()
+    rm_namespace_and_prefix_fn = fn(name, namespace, prefix) -> name end
+    assert XmlToMap.naive_map(amazon_xml(), %{namespace_match_fn: rm_namespace_and_prefix_fn}) == amazon_expected()
   end
 
   test "empty tag => nil" do
@@ -34,14 +35,7 @@ defmodule XmlToMapTest do
   end
 
   test "support for xmlns xml file" do
-    replace_namespace_fn = fn(name, namespace, prefix) ->
-      cond do
-        namespace != [] && prefix != [] -> "#{prefix}:#{name}"
-        true -> name 
-      end
-    end
-
-    assert XmlToMap.naive_map(facebook_xmlns_xml, replace_namespace_fn) == facebook_xmlns_xml_expected
+    assert XmlToMap.naive_map(facebook_xmlns_xml, %{namespace_match_fn: XmlToMap.default_namespace_match_fn }) == facebook_xmlns_xml_expected
   end
 
   def expectation do

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -7,8 +7,7 @@ defmodule XmlToMapTest do
   end
 
   test "combines sibling nodes with the same name into a list" do
-    rm_namespace_and_prefix_fn = fn(name, namespace, prefix) -> name end
-    assert XmlToMap.naive_map(amazon_xml(), %{namespace_match_fn: rm_namespace_and_prefix_fn}) == amazon_expected()
+    assert XmlToMap.naive_map(amazon_xml()) == amazon_expected()
   end
 
   test "empty tag => nil" do
@@ -35,7 +34,7 @@ defmodule XmlToMapTest do
   end
 
   test "support for xmlns xml file" do
-    assert XmlToMap.naive_map(facebook_xmlns_xml, %{namespace_match_fn: XmlToMap.default_namespace_match_fn }) == facebook_xmlns_xml_expected
+    assert XmlToMap.naive_map(facebook_xmlns_xml(), [namespace_match_fn: &XmlToMap.default_namespace_match_fn/0]) == facebook_xmlns_xml_expected()
   end
 
   def expectation do

--- a/test/elixir_xml_to_map_test.exs
+++ b/test/elixir_xml_to_map_test.exs
@@ -7,7 +7,7 @@ defmodule XmlToMapTest do
   end
 
   test "combines sibling nodes with the same name into a list" do
-    assert XmlToMap.naive_map(amazon_xml()) == amazon_expected()
+    assert XmlToMap.naive_map(amazon_xml(), fn(name, namespace, prefix) -> name end) == amazon_expected()
   end
 
   test "empty tag => nil" do
@@ -31,6 +31,17 @@ defmodule XmlToMapTest do
                }
              }
            }
+  end
+
+  test "support for xmlns xml file" do
+    replace_namespace_fn = fn(name, namespace, prefix) ->
+      cond do
+        namespace != [] && prefix != [] -> "#{prefix}:#{name}"
+        true -> name 
+      end
+    end
+
+    assert XmlToMap.naive_map(facebook_xmlns_xml, replace_namespace_fn) == facebook_xmlns_xml_expected
   end
 
   def expectation do
@@ -257,6 +268,70 @@ defmodule XmlToMapTest do
         "ResponseMetadata" => %{"RequestId" => "7509cdb2-0b69-4ca0-89dc-c77f8a747834"}
       }
     }
+  end
+
+  def facebook_xmlns_xml_expected do
+    %{
+      "rss" => %{
+        "#content" => %{
+          "channel" => %{
+            "title" => "Test Store",
+            "link" => "http://www.example.com",
+            "description" => "An example item from the feed",
+            "item" => %{
+              "g:id" => "DB_1",
+              "g:title" => "Dog Bowl In Blue",
+              "g:description" => "Solid plastic Dog Bowl in marine blue color",
+              "g:link" => "http://www.example.com/bowls/db-1.html",
+              "g:image_link" => "http://images.example.com/DB_1.png",
+              "g:brand" => "Example",
+              "g:condition" => "new",
+              "g:availability" => "in stock",
+              "g:price" => "9.99 GBP",
+              "g:shipping" => %{
+                "g:country" => "UK",
+                "g:service" => "Standard",
+                "g:price" => "4.95 GBP",
+              },
+              "g:google_product_category" => "Animals > Pet Supplies",
+              "g:custom_label_0" => "Made in Waterford, IE",
+            }
+          }
+        },
+        "-version" => "2.0"
+      }
+    }
+  end
+
+  def facebook_xmlns_xml do
+    """
+    <?xml version="1.0"?>
+    <rss xmlns:g="http://base.google.com/ns/1.0" version="2.0">
+      <channel>
+        <title>Test Store</title>
+        <link>http://www.example.com</link>
+        <description>An example item from the feed</description>
+        <item>
+          <g:id>DB_1</g:id>
+          <g:title>Dog Bowl In Blue</g:title>
+          <g:description>Solid plastic Dog Bowl in marine blue color</g:description>
+          <g:link>http://www.example.com/bowls/db-1.html</g:link>
+          <g:image_link>http://images.example.com/DB_1.png</g:image_link>
+          <g:brand>Example</g:brand>
+          <g:condition>new</g:condition>
+          <g:availability>in stock</g:availability>
+          <g:price>9.99 GBP</g:price>
+          <g:shipping>
+          <g:country>UK</g:country>
+          <g:service>Standard</g:service>
+          <g:price>4.95 GBP</g:price>
+          </g:shipping>
+          <g:google_product_category>Animals > Pet Supplies</g:google_product_category>
+          <g:custom_label_0>Made in Waterford, IE</g:custom_label_0>
+        </item>
+      </channel>
+    </rss>
+    """
   end
 
   def amazon_xml do


### PR DESCRIPTION
Address this issue problem https://github.com/homanchou/elixir-xml-to-map/issues/15.

to resolve this problem, we can pass a function as second parameter to `XmlToMap.naive_map`, so I can make a function to set the name as "#{prefix}:{name}", for example:

```elixir
replace_namespace_fn = fn(name, namespace, prefix) ->
      cond do
        namespace != [] && prefix != [] -> "#{prefix}:#{name}"
        true -> name 
      end
    end
```

If we have a xml file like this:
```xml
<?xml version="1.0"?>
    <rss xmlns:g="http://base.google.com/ns/1.0" version="2.0">
      <channel>
        <title>Test Store</title>
        <link>http://www.example.com</link>
        <description>An example item from the feed</description>
        <item>
          <g:id>DB_1</g:id>
          <g:title>Dog Bowl In Blue</g:title>
          <g:description>Solid plastic Dog Bowl in marine blue color</g:description>
          <g:link>http://www.example.com/bowls/db-1.html</g:link>
          <g:image_link>http://images.example.com/DB_1.png</g:image_link>
          <g:brand>Example</g:brand>
          <g:condition>new</g:condition>
          <g:availability>in stock</g:availability>
          <g:price>9.99 GBP</g:price>
          <g:shipping>
          <g:country>UK</g:country>
          <g:service>Standard</g:service>
          <g:price>4.95 GBP</g:price>
          </g:shipping>
          <g:google_product_category>Animals > Pet Supplies</g:google_product_category>
          <g:custom_label_0>Made in Waterford, IE</g:custom_label_0>
        </item>
      </channel>
    </rss>
 ```
 
 it will output:
 ```elixir
 %{
      "rss" => %{
        "#content" => %{
          "channel" => %{
            "title" => "Test Store",
            "link" => "http://www.example.com",
            "description" => "An example item from the feed",
            "item" => %{
              "g:id" => "DB_1",
              "g:title" => "Dog Bowl In Blue",
              "g:description" => "Solid plastic Dog Bowl in marine blue color",
              "g:link" => "http://www.example.com/bowls/db-1.html",
              "g:image_link" => "http://images.example.com/DB_1.png",
              "g:brand" => "Example",
              "g:condition" => "new",
              "g:availability" => "in stock",
              "g:price" => "9.99 GBP",
              "g:shipping" => %{
                "g:country" => "UK",
                "g:service" => "Standard",
                "g:price" => "4.95 GBP",
              },
              "g:google_product_category" => "Animals > Pet Supplies",
              "g:custom_label_0" => "Made in Waterford, IE",
            }
          }
        },
        "-version" => "2.0"
      }
    }
    ```