### PR TITLE
chore(readme): update to extra_applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The package can be installed as:
 
     ```elixir
     def application do
-      [applications: [:elixir_xml_to_map]]
+      [extra_applications: [:elixir_xml_to_map]]
     end
     ```
 


### PR DESCRIPTION
Using `application` will cause conflicts since it essentially creates a monopoly and does not allow other apps to work.  You can check this by using applications and then trying to add Oban, for example, to your project. 

In any case, we should be using `extra_applications` now instead of `applications` which exists for compatibility reasons.